### PR TITLE
Support for ECS Tasks using bridge networking mode with ephemeral host ports

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
 FROM golang:1.15 as builder
 WORKDIR /src
-COPY go.* .
-RUN go mod vendor
 COPY . .
+RUN go mod vendor
 ARG TARGETOS
 ARG TARGETARCH
 RUN CGO_ENABLED=0 GO111MODULE=on GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -a -mod=vendor -tags=netgo -o config-reloader cmd/main.go 

--- a/pkg/aws/cloudmap.go
+++ b/pkg/aws/cloudmap.go
@@ -13,6 +13,7 @@ import (
 const (
 	ScrapeConfigParmeter    = "ECS-Scrape-Configuration"
 	IpAddressAttribute      = "AWS_INSTANCE_IPV4"
+	PortNumberAttribute     = "AWS_INSTANCE_PORT"
 	ClusterNameAttribute    = "ECS_CLUSTER_NAME"
 	ServiceNameAttribute    = "ECS_SERVICE_NAME"
 	TaskDefinitionAttribute = "ECS_TASK_DEFINITION_FAMILY"
@@ -154,8 +155,12 @@ func (c *CloudMapClient) getInstanceScrapeConfiguration(sdInstance *ServiceDisco
 	labels := make(map[string]string)
 	targets := make([]string, 0)
 
+	// Port number of the resource is available, by default, as an attribute with the key 'AWS_INSTANCE_PORT'
+	defaultPort, present := sdInstance.attributes[PortNumberAttribute]
+	if !present {
+		defaultPort = aws.String("80")
+	}
 	// Metrics port is expected as a resource tag with the key 'METRICS_PORT'
-	defaultPort := aws.String("80")
 	metricsPort, present := serviceTags[MetricsPortTag]
 	if !present {
 		metricsPort = defaultPort


### PR DESCRIPTION
*Issue #, if available:* -

*Description of changes:*
When a custom port is not supplied using Service Discovery Instance tags, current logic defaults to port 80. For ECS tasks that use bridge networking mode without specifying a host port for container ports, it is impossible to know the assigned host port on runtime, thus Service Discovery Instance tags cannot be used to specify the correct port for this container to scrape from. Although, the assigned host port is registered as an attribute named `AWS_INSTANCE_PORT` on Service Discovery Instance and we already have this info in the current code. This PR changes the logic so that if no custom port is specified using Service Discovery Instance tag `METRICS_PORT`, `AWS_INSTANCE_PORT` attribute of the instance is used instead of the default port 80. And if there is no `AWS_INSTANCE_PORT` attribute on the Service Discovery Instance, then the default port 80 is used like before.

Also modified Dockerfile because docker build was failing due to `go mod vendor` command not working properly with only `go.mod` and `go.sum` present in the directory. So instead now it copies the whole folder, and then runs `go mod vendor` which ran without a problem for me. I'm not an expert in Golang, there might be something I'm missing, feel free to correct me

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
