### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,13 @@
 FROM golang:1.15 as builder
 WORKDIR /src
-COPY go.* /src/
+COPY . .
 RUN go env -w GOPROXY=direct
 RUN go mod download
+RUN go mod tidy
 RUN go mod vendor
-COPY . .
 ARG TARGETOS
 ARG TARGETARCH
 RUN CGO_ENABLED=0 GO111MODULE=on GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -a -mod=vendor -tags=netgo -o config-reloader cmd/main.go 
-
 
 FROM alpine:latest AS final
 WORKDIR /home/prometheus-for-ecs


### PR DESCRIPTION
Fix vendoring error:

 => ERROR [builder 8/8] RUN CGO_ENABLED=0 GO111MODULE=on GOOS=linux GOARCH=amd64 go build -a -mod=vendor -tags=netgo -o config-reloader cmd/main.go                                                                                                                     0.3s
------                                                                                                                                                                                                                                                                       
 > [builder 8/8] RUN CGO_ENABLED=0 GO111MODULE=on GOOS=linux GOARCH=amd64 go build -a -mod=vendor -tags=netgo -o config-reloader cmd/main.go:                                                                                                                                
0.316 pkg/aws/cloudmap.go:9:2: cannot find package "." in:                                                                                                                                                                                                                   
0.316   /src/vendor/github.com/aws/aws-sdk-go/aws                                                                                                                                                                                                                            
0.316 pkg/aws/session.go:8:2: cannot find package "." in:                                                                                                                                                                                                                    
0.316   /src/vendor/github.com/aws/aws-sdk-go/aws/session                                                                                                                                                                                                                    
0.316 pkg/aws/cloudmap.go:10:2: cannot find package "." in:
0.316   /src/vendor/github.com/aws/aws-sdk-go/service/servicediscovery
0.316 pkg/aws/ssm.go:7:2: cannot find package "." in:
0.316   /src/vendor/github.com/aws/aws-sdk-go/service/ssm
------

 1 warning found (use docker --debug to expand):
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 1) Dockerfile:10
--------------------
   8 |     ARG TARGETOS
   9 |     ARG TARGETARCH
  10 | >>> RUN CGO_ENABLED=0 GO111MODULE=on GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -a -mod=vendor -tags=netgo -o config-reloader cmd/main.go 
  11 |     
  12 |     
--------------------
ERROR: failed to solve: process "/bin/sh -c CGO_ENABLED=0 GO111MODULE=on GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -a -mod=vendor -tags=netgo -o config-reloader cmd/main.go" did not complete successfully: exit code: 1

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
